### PR TITLE
fixed a edge case with wrapper element

### DIFF
--- a/src/webpack/entry.browser.js
+++ b/src/webpack/entry.browser.js
@@ -18,7 +18,7 @@ if (urlParams.has('test')) {
 
     ReactDOM.render(component, document.getElementById('main'));
 } else {
-    const wrapper = document.createElement('div');
+    const wrapper = document.getElementById('main') || document.createElement('div');
     wrapper.style.setProperty('display', 'grid');
     wrapper.style.setProperty('grid-template-columns', '300px auto');
     wrapper.style.setProperty('grid-gap', '1em');


### PR DESCRIPTION
Sometimes the wrapper element got a absolute height, before we added a new `div` on the bottom. The overview page was always an blank page, but if you scrolled down you saw the tests