### PR TITLE
bail on docker errors while setting up tests

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -63,6 +63,7 @@ module.exports.setup = async function setup({ noInfo } = { noInfo: true }) {
             console.log('\nStarting Docker for screenshots...');
         } catch (e) {
             console.error(e);
+            throw new Error('Failed to start docker for screenshots');
         }
     }
 };


### PR DESCRIPTION
prevents running screenshot tests in a local Chrome installation. fails faster and more accurate in CI setup.