### PR TITLE
Add renderOptions.before/after

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ module.exports = {
     port: 1111,
     renderOptions: {
         viewport: { deviceScaleFactor: 2 },
+
+        // function calls before page.goto()
+        before: (page) => {
+            // for example, disable cache
+            await page.setCacheEnabled(false);
+        },
+
+        // function calls after page.goto()
+        after: (page) => {},
     },
 };
 ```

--- a/src/render.js
+++ b/src/render.js
@@ -20,12 +20,20 @@ async function render(reactNode, options) {
         pageConfig.waitUntil = opts.waitUntil;
     }
 
+    if (opts.before) {
+        await opts.before(page);
+    }
+
     debug('page.goto ' + url);
     await page.goto(url, pageConfig);
 
     if (opts.viewport) {
         debug('setting a viewport from options');
         await page.setViewport(opts.viewport);
+    }
+
+    if (opts.after) {
+        await opts.after(page);
     }
 
     return page;


### PR DESCRIPTION
Add ability to configure page globaly or per test (disable cache for example)

Motivation:
I have >300 tests and try to run it in parallel (jest do it by default).
Sometimes my tests fails and render blank page. I've found that chrome fails to load some assets with `net::err_cache_write_failure` error. May be this is chromium bug or chromium+docker problem.
`page.setCacheEnabled(false)` resolves my problems