### PR TITLE
updating to setupFilesAfterEnv

### DIFF
--- a/jest-preset.json
+++ b/jest-preset.json
@@ -2,6 +2,6 @@
     "globalSetup": "jest-puppeteer-react/globalSetup",
     "globalTeardown": "jest-puppeteer-react/globalTeardown",
     "testEnvironment": "jest-puppeteer-react/environment",
-    "setupTestFrameworkScriptFile":
-        "jest-puppeteer-react/expect-puppeteer-react"
+    "setupFilesAfterEnv:":
+        ["jest-puppeteer-react/expect-puppeteer-react"]
 }


### PR DESCRIPTION
Description: In the last release of Jest 24.0.0 the configuration for scripts to run before tests are changed, deprecating setupTestFrameworkScriptFile: String in favor of setupFilesAfterEnv: []