### PR TITLE
fix rootDir arg for starting webpack standalone

### DIFF
--- a/bin/debug.js
+++ b/bin/debug.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../globalSetup.js')({ noInfo: false });
+require('../globalSetup.js')({ noInfo: false, rootDir: process.cwd() });


### PR DESCRIPTION
regression from #45 