### PR TITLE
Allow to configure webpack-dev-server

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -92,6 +92,7 @@ module.exports.setup = async function setup(
         noInfo,
         disableHostCheck: true,
         stats: 'minimal',
+        ...(webpackConfig.devServer || {})
     });
 
     const port = config.port || 1111;


### PR DESCRIPTION
I want to configure webpack-dev-server with standard configuration https://webpack.js.org/configuration/dev-server