### PR TITLE
Return page in browser render() function

### DIFF
--- a/src/webpack/render.browser.js
+++ b/src/webpack/render.browser.js
@@ -12,4 +12,6 @@ export const render = async (reactNode, options) => {
         reactNode,
         path: [...window.__path],
     });
+    
+    return window.page;
 };


### PR DESCRIPTION
So I can use `render()` without define globals. Very useful for TypeScript environment

```
it('test', async() => {
   const page = await render('<div/>');
   const screenshot = await page.screenshot({ fullPage: true });
   expect(screenshot).toMatchImageSnapshot();
})
```